### PR TITLE
Made SettingViewModel non-shared

### DIFF
--- a/src/Gemini/Modules/Settings/ViewModels/SettingsViewModel.cs
+++ b/src/Gemini/Modules/Settings/ViewModels/SettingsViewModel.cs
@@ -10,6 +10,7 @@ using Gemini.Properties;
 namespace Gemini.Modules.Settings.ViewModels
 {
     [Export(typeof (SettingsViewModel))]
+    [PartCreationPolicy (CreationPolicy.NonShared)]
     public class SettingsViewModel : WindowBase
     {
         private IEnumerable<ISettingsEditor> _settingsEditors;


### PR DESCRIPTION
When you open the Tools->Options and change a setting then click Cancel the user would assume that opening the Options window again would show the original setting however it currently shows the unsaved settings that the user selected before clicking Cancel. Changing the PartCreationPolicy to NonShared fixes this issue.